### PR TITLE
Transfer playback between spotify devices

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -651,7 +651,15 @@ class SpotifySkill(MycroftSkill):
                 self.speak_dialog('NoDevicesAvailable')
         else:
             self.speak_dialog('NotAuthorized')
-
+    @intent_handler(IntentBuilder('').require('Transfer').require('Spotify') \
+                                     .require('ToDevice'))
+    def transfer_playback(self, message):
+        """ Move playback from one device to another. """
+        if self.spotify and self.spotify.is_playing():
+            dev = self.spotify.get_device(message.data['ToDevice'])
+            if dev:
+                self.spotify.transfer_playback(dev['id'])
+            
     def show_notes(self):
         """ show notes, HA HA """
         self.schedule_repeating_event(self._update_notes,

--- a/regex/en-us/ToDevice.rx
+++ b/regex/en-us/ToDevice.rx
@@ -1,0 +1,1 @@
+to (?P<ToDevice>.+)

--- a/vocab/en-us/Transfer.voc
+++ b/vocab/en-us/Transfer.voc
@@ -1,0 +1,2 @@
+transfer
+move


### PR DESCRIPTION
- `move spotify playback to <device>` will try to move the music stream as indicated.
- Cache device list for 10 seconds to reduce number of times we're hitting the API
- Try the device hostname to make the skill find the desktop client
- Clean up some of the device related code
