### PR TITLE
Bugfix for #25: better error message

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -591,6 +591,10 @@ class SpotifySkill(MycroftSkill):
             TODO: improve results of albums by checking artist
         """
         dev = self.get_default_device()
+        if not dev:
+            self.speak_dialog('NoDefaultDeviceAvailable')
+            return
+
         res = None
         if search_type == 'album' and len(query.split('by')) > 1:
             title, artist = query.split('by')

--- a/dialog/en-us/NoDefaultDeviceAvailable.dialog
+++ b/dialog/en-us/NoDefaultDeviceAvailable.dialog
@@ -1,0 +1,2 @@
+I couldn't find any default Spot-ify device.  Make sure Spot-ify is running, or that the skill has been configured to use the default libraries
+There's no default Spot-ify device available. Make sure Spot-ify is running, or that the skill has been configured to use the default libraries


### PR DESCRIPTION
Previously the skill tried to start playback even when no default device
was available. This fix adds some dialog output to inform the user about
this misconfiguration.

See #25 for testing steps

(cherry picked from commit d76f6b517a933ccfff0dc9b5bc3560c28a59b315)