### PR TITLE
Refine UI text, duck on remote only

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -79,6 +79,7 @@ class SpotifySkill(CommonPlaySkill):
         self.dev_id = None
         self.idle_count = 0
         self.ducking = False
+        self.is_player_remote = False   # when dev is remote control instance
         self.mouth_text = None
         self.librespot_starting = False
 
@@ -181,6 +182,14 @@ class SpotifySkill(CommonPlaySkill):
             # been connected
             self.device_name = DeviceApi().get().get('name')
 
+    def failed_auth(self):
+        if not self.settings["user"]:
+            # Assume this is initial setup
+            self.speak_dialog('NotConfigured')
+        else:
+            # Assume password changed or there is a typo
+            self.speak_dialog('NotAuthorized')
+
     ######################################################################
     # Handle auto ducking when listener is started.
 
@@ -191,7 +200,7 @@ class SpotifySkill(CommonPlaySkill):
 
         TODO: Evaluate the Idle check logic
         """
-        if self.spotify.is_playing() and \
+        if self.spotify.is_playing() and self.is_player_remote and
                 self.settings.get('use_ducking', False):
             self.__pause()
             self.ducking = True
@@ -430,8 +439,7 @@ class SpotifySkill(CommonPlaySkill):
             self.speak_dialog('PlaybackFailed',
                 {'reason': self.translate('NoDevicesAvailable')})
         except SpotifyNotAuthorizedError:
-            self.speak_dialog('PlaybackFailed',
-                {'reason': self.translate('NotAuthorized')})
+            self.failed_auth()
         except PlaylistNotFoundError:
             self.speak_dialog('PlaybackFailed',
                 {'reason': self.translate('PlaylistNotFound')})
@@ -503,15 +511,19 @@ class SpotifySkill(CommonPlaySkill):
             dev = None
             if default_device:
                 dev = self.device_by_name(default_device)
+                self.is_player_remote = True
             # if not set or missing try playing on this device
             if not dev:
                 dev = self.device_by_name(self.device_name)
+                self.is_player_remote = False
             # if not check if a desktop spotify client is playing
             if not dev:
                 dev = self.device_by_name(gethostname())
+                self.is_player_remote = False
             # use first best device if none of the prioritized works
             if not dev and len(self.devices) > 0:
                 dev = self.devices[0]
+                self.is_player_remote = True  # ?? Guessing it is remote
             if dev and not dev['is_active']:
                 self.spotify.transfer_playback(dev['id'], False)
             return dev
@@ -719,14 +731,14 @@ class SpotifySkill(CommonPlaySkill):
         if self.spotify:
             self.spotify.shuffle(True)
         else:
-            self.speak_dialog('NotAuthorized')
+            self.failed_auth()
 
     def shuffle_off(self):
         """ Turn off shuffling """
         if self.spotify:
             self.spotify.shuffle(False)
         else:
-            self.speak_dialog('NotAuthorized')
+            self.failed_auth()
 
     def __pause(self):
         # if authorized and playback was started by the skill
@@ -781,7 +793,7 @@ class SpotifySkill(CommonPlaySkill):
             else:
                 self.speak_dialog('NoDevicesAvailable')
         else:
-            self.speak_dialog('NotAuthorized')
+            self.failed_auth()
 
     @intent_handler(IntentBuilder('').require('Transfer').require('Spotify')
                                      .require('ToDevice'))
@@ -796,7 +808,7 @@ class SpotifySkill(CommonPlaySkill):
                 self.speak_dialog('DeviceNotFound',
                                   {'name': message.data['ToDevice']})
         elif not self.spotify:
-            self.speak_dialog('NotAuthorized')
+            self.failed_auth()
         else:
             self.speak_dialog('NothingPlaying')
 

--- a/__init__.py
+++ b/__init__.py
@@ -200,8 +200,8 @@ class SpotifySkill(CommonPlaySkill):
 
         TODO: Evaluate the Idle check logic
         """
-        if self.spotify.is_playing() and self.is_player_remote and
-                self.settings.get('use_ducking', False):
+        if (self.spotify.is_playing() and self.is_player_remote and
+                self.settings.get('use_ducking', False)):
             self.__pause()
             self.ducking = True
 

--- a/locale/en-us/NotAuthorized.dialog
+++ b/locale/en-us/NotAuthorized.dialog
@@ -1,3 +1,1 @@
-I'm not connected to a Spotify account, go to home dot mycroft dot ai to authorize the skill.
-This device isn't associated with a Spotify account, go to home dot mycroft dot ai to authorize me.
-Please authorize the Spotify skill on home dot mycroft dot ai to access your account
+Unable to authorize with the Spotify service.  Please go to Skill settings at home.mycroft.ai to verify your username and password and to Connect to Spotify.

--- a/locale/en-us/NotAuthorized.dialog
+++ b/locale/en-us/NotAuthorized.dialog
@@ -1,1 +1,1 @@
-Unable to authorize with the Spotify service.  Please go to Skill settings at home.mycroft.ai to verify your username and password and to Connect to Spotify.
+Unable to authorize with the Spotify service. Please go to Skill settings at home dot mycroft dot ai to verify your username and password and to Connect to Spotify.

--- a/locale/en-us/NotConfigured.dialog
+++ b/locale/en-us/NotConfigured.dialog
@@ -1,0 +1,1 @@
+I'm not connected to your Spotify account yet.  Go to home dot mycroft dot ai to setup your Spotify skill.

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -8,7 +8,7 @@
                     {
                         "type": "label",
                         "value": "",
-                        "label": "You must connect to a Spotify Premium account to access music.  Provide your Spotify username/password and then Connect with the button below.<p/>"
+                        "label": "You must have a Spotify Premium account to access music.  Provide your Spotify username/password and then Connect with the button below.<p/>"
                     },
                     {
                         "name": "user",
@@ -23,48 +23,48 @@
                         "label": "Password",
                         "value": ""
                     },
-                    {
-                        "name": "Spotify",
-                        "type": "oauth",
-                        "value": 1
-                    }
-                ]
-            },
-            {
-                "name": "Spotify Device",
-                "fields": [
-                    {
-                        "type": "label",
-                        "value": "",
-                        "label": "If you want the skill to default to a specific Spotify device set it below. If not set the player on the Mycroft unit will be used<p/>"
-                    },
-                    {
-                        "name": "default_device",
-                        "type": "text",
-                        "label": "Spotify Device",
-                        "value": "",
-                        "placeholder": ""
-                    }
-                ]
-            },
-            {
-                "name": "Audio Ducking",
-                "fields": [
-                    {
-                        "type": "label",
-                        "value": "",
-                        "label": "Pause Spotify when wakeword is detected<p/>"
-                    },
-                    {
-                        "name": "use_ducking",
-                        "type": "checkbox",
-                        "label": "Use audio ducking",
-                        "value": "false",
-                        "placeholder": ""
-                    }
-                ]
-            }
-
+          {
+            "type": "label",
+            "value": "",
+            "label": "Click the Save button at the top of your screen, then use the Connect button to authorize with Spotify<p/>"
+          },
+          {
+            "name": "Spotify",
+            "type": "oauth",
+            "value": 1
+          }
         ]
-    }
+      },
+      {
+        "name": "Remote Control Device",
+        "fields": [
+          {
+            "type": "label",
+            "value": "",
+            "label": "Playback normally occurs using Mycroft's speaker.  You can also use another Spotify device for playback and remotely control it using Mycroft.<p/>"
+          },
+          {
+            "name": "default_device",
+            "type": "text",
+            "label": "Spotify device",
+            "value": "",
+            "placeholder": "default (Mycroft's speaker)"
+          },
+          {
+            "type": "label",
+            "value": "",
+            "label": "Pause remote music when Mycroft is listening or talking.<p/>"
+          },
+          {
+            "name": "use_ducking",
+            "type": "checkbox",
+            "label": "Auto-pause",
+            "value": "false",
+            "placeholder": ""
+          }
+        ]
+      }
+    ]
+  }
 }
+


### PR DESCRIPTION
Several minor UI refinements:
* Massaged the UI text for settings
* Changed the error message when the system hasn't been setup at all
* Distinguish ducking to only apply to remote Spotify playback devices