### PR TITLE
Make sure the process is cleared on librespot_stop

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -869,7 +869,8 @@ class SpotifySkill(CommonPlaySkill):
         if self.process and self.process.poll() is None:
             self.process.send_signal(signal.SIGTERM)
             self.process.communicate()  # Communicate to remove zombie
-            self.process = None
+
+        self.process = None
 
     def shutdown(self):
         """ Remove the monitor at shutdown. """


### PR DESCRIPTION
Always clear the processes reference after librespot stop. Previously this was not done if the process had exited on it's own.