### PR TITLE
Update US English artist regex for more common phrases

### DIFF
--- a/locale/en-us/artist.regex
+++ b/locale/en-us/artist.regex
@@ -1,1 +1,1 @@
-(the artist|the group|the band|something by) (?P<artist>.+)
+(the artist|the group|the band|(something|anything|stuff|music|songs) (by|from)) (?P<artist>.+)


### PR DESCRIPTION
Expands the artist regex to cover a few new combinations. For instance:
"Play music by `<artist>`"
"Play something from `<artist>`"
"Play stuff by `<artist>`"