### PR TITLE
Serve icon from githack CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src='Spotify_Icon.png' card_color='#40db60' width='50' height='50' style='vertical-align:bottom'/> Spotify
+# <img src='https://rawcdn.githack.com/forslund/spotify-skill/05c19c0fba8a4af150c6eb8cf2e955d59ac83d15/Spotify_Icon.png' card_color='#40db60' width='50' height='50' style='vertical-align:bottom'/> Spotify
 Listen to music from your Spotify Premium music account
 
 ## About


### PR DESCRIPTION
Icons served directly from Github can be blocked from rendering remotely. This switches to Githack CDN