### PR TITLE
Add support for playing saved songs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -172,7 +172,7 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
-        self.saved_tracks = None
+        self.saved_tracks = []
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False

--- a/__init__.py
+++ b/__init__.py
@@ -795,7 +795,7 @@ class SpotifySkill(CommonPlaySkill):
                     self._saved_tracks.append(item['track'])
 
                 offset += 50
-                if not batch.next:
+                if not batch['next']:
                     break
 
             self.__saved_tracks_fetched = now

--- a/__init__.py
+++ b/__init__.py
@@ -480,7 +480,7 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
-            return (1.0, {'items': self.saved_tracks,
+            return (1.0, {'data': self.saved_tracks,
                           'type': 'saved_tracks'})
 
         # Check if playlist
@@ -963,7 +963,7 @@ class SpotifySkill(CommonPlaySkill):
         """
         try:
             if data_type == 'saved_tracks':
-                items = data['items']
+                items = data
                 random.shuffle(items)
                 uris = []
                 for item in items:

--- a/__init__.py
+++ b/__init__.py
@@ -423,7 +423,7 @@ class SpotifySkill(CommonPlaySkill):
             self.log.info('Spotify confidence: {}'.format(confidence))
             self.log.info('              data: {}'.format(data))
 
-            if data.get('type') in ['album', 'artist', 'track', 'playlist']:
+            if data.get('type') in ['saved_tracks', 'album', 'artist', 'track', 'playlist']:
                 if spotify_specified:
                     # " play great song on spotify'
                     level = CPSMatchLevel.EXACT
@@ -963,13 +963,13 @@ class SpotifySkill(CommonPlaySkill):
         """
         try:
             if data_type == 'saved_tracks':
-                items = data['saved_tracks']['items']
+                items = data['items']
                 random.shuffle(items)
                 uris = []
                 for item in items:
-                    uris.append(item['uri'])
-                data = {'track': items[0]['name'],
-                        'artist': items[0]['artists'][0]['name']}
+                    uris.append(item['track']['uri'])
+                data = {'track': items[0]['track']['name'],
+                        'artist': items[0]['track']['artists'][0]['name']}
                 self.speak_dialog('ListeningToSavedSongs', data)
                 time.sleep(2)
                 self.spotify_play(dev['id'], uris=uris)

--- a/__init__.py
+++ b/__init__.py
@@ -791,7 +791,7 @@ class SpotifySkill(CommonPlaySkill):
             offset = 0
             while True:
                 batch = self.spotify.current_user_saved_tracks(50, offset)
-                for item in batch.get('items', [])
+                for item in batch.get('items', []):
                     self._saved_tracks.append(item['track'])
 
                 offset += 50

--- a/__init__.py
+++ b/__init__.py
@@ -485,7 +485,7 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match and self.saved_tracks:
-            return (1.0, {'data': self.saved_tracks,
+            return (1.0, {'data': None,
                           'type': 'saved_tracks'})
 
         # Check if playlist
@@ -975,13 +975,13 @@ class SpotifySkill(CommonPlaySkill):
         """
         try:
             if data_type == 'saved_tracks':
-                items = data
+                # Grab 200 random songs
+                # Spotify doesn't like it when we send thousands of songs
+                items = random.sample(self.saved_tracks, 200)
                 uris = []
                 for item in items:
                     uris.append(item['uri'])
-                data = {'track': items[0]['name'],
-                        'artist': items[0]['artists'][0]['name']}
-                self.speak_dialog('ListeningToSavedSongs', data)
+                self.speak_dialog('ListeningToSavedSongs')
                 time.sleep(2)
                 self.spotify_play(dev['id'], uris=uris)
             elif data_type == 'track':

--- a/__init__.py
+++ b/__init__.py
@@ -796,7 +796,7 @@ class SpotifySkill(CommonPlaySkill):
 
         # Grab count random tracks
         for i in range(0, count):
-            songs.append(self.spotify.current_user_saved_tracks(1, random.randint(0, total)).get('items', [])
+            songs.append(self.spotify.current_user_saved_tracks(1, random.randint(0, total)).get('items', []))
 
         return songs
 

--- a/__init__.py
+++ b/__init__.py
@@ -787,8 +787,17 @@ class SpotifySkill(CommonPlaySkill):
             return []
         now = time.time()
         if not self._saved_tracks or (now - self.__saved_tracks_fetched > 5 * 60):
-            self._saved_tracks = {}
-            self._saved_tracks = self.spotify.current_user_saved_tracks().get('items', [])
+            self._saved_tracks = []
+            offset = 0
+            while True:
+                batch = self.spotify.current_user_saved_tracks(50, offset)
+                for item in batch.get('items', [])
+                    self._saved_tracks.append(item['track'])
+
+                offset += 50
+                if not batch.next:
+                    break
+
             self.__saved_tracks_fetched = now
         return self._saved_tracks
 

--- a/__init__.py
+++ b/__init__.py
@@ -977,9 +977,9 @@ class SpotifySkill(CommonPlaySkill):
         try:
             if data_type == 'saved_tracks':
                 items = data
-                # Grab up to 50 random songs
+                # Grab up to 100 random songs
                 # Prevents mycroft-playback-control.mycroftai:PlayQueryTimeout
-                random.sample(items, min(50, len(items)))
+                random.sample(items, min(100, len(items)))
                 uris = []
                 for item in items:
                     uris.append(item['uri'])

--- a/__init__.py
+++ b/__init__.py
@@ -486,6 +486,7 @@ class SpotifySkill(CommonPlaySkill):
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
             return (1.0, {'data': self.saved_tracks,
+                          'name': None,
                           'type': 'saved_tracks'})
 
         # Check if playlist

--- a/__init__.py
+++ b/__init__.py
@@ -979,7 +979,7 @@ class SpotifySkill(CommonPlaySkill):
                 items = data
                 # Grab up to 100 random songs
                 # Prevents mycroft-playback-control.mycroftai:PlayQueryTimeout
-                random.sample(items, min(100, len(items)))
+                random.choices(items, k=min(100, len(items)))
                 uris = []
                 for item in items:
                     uris.append(item['uri'])

--- a/__init__.py
+++ b/__init__.py
@@ -977,7 +977,9 @@ class SpotifySkill(CommonPlaySkill):
         try:
             if data_type == 'saved_tracks':
                 items = data
-                random.shuffle(items)
+                # Grab up to 100 random songs
+                # Prevents mycroft-playback-control.mycroftai:PlayQueryTimeout
+                random.sample(items, min(100, len(items)))
                 uris = []
                 for item in items:
                     uris.append(item['uri'])

--- a/__init__.py
+++ b/__init__.py
@@ -480,8 +480,8 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
-            return (1.0, {'data': self.saved_tracks,
-                           'type': 'saved_tracks'})
+            return (1.0, {'items': self.saved_tracks,
+                          'type': 'saved_tracks'})
 
         # Check if playlist
         match = re.match(self.translate_regex('playlist'), phrase)

--- a/__init__.py
+++ b/__init__.py
@@ -172,6 +172,7 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
+        self._saved_tracks = None
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
@@ -468,7 +469,7 @@ class SpotifySkill(CommonPlaySkill):
         """
         Check if the phrase can be matched against a specific spotify request.
 
-        This includes asking for playlists, albums, artists or songs.
+        This includes asking for saved items, playlists, albums, artists or songs.
 
         Arguments:
             phrase (str): Text to match against
@@ -476,6 +477,11 @@ class SpotifySkill(CommonPlaySkill):
 
         Returns: Tuple with confidence and data or NOTHING_FOUND
         """
+        # Check if saved
+        match = re.match(self.translate_regex('saved_songs'), phrase)
+        if match:
+            return self.query_saved_songs()
+
         # Check if playlist
         match = re.match(self.translate_regex('playlist'), phrase)
         if match:
@@ -774,6 +780,20 @@ class SpotifySkill(CommonPlaySkill):
         return self._playlists
 
     @property
+    def saved_tracks(self):
+        """Saved tracks, cached for 5 minutes."""
+        if not self.spotify:
+            return []
+        now = time.time()
+        if not self._saved_tracks or (now - self.__saved_tracks_fetched > 5 * 60):
+            self._saved_tracks = {}
+            tracks = self.spotify.current_user_saved_tracks().get('items', [])
+            for t in tracks:
+                self._saved_tracks[t['name'].lower()] = t
+            self.__saved_tracks_fetched = now
+        return self._saved_tracks
+
+    @property
     def devices(self):
         """Devices, cached for 60 seconds."""
         if not self.spotify:
@@ -937,13 +957,24 @@ class SpotifySkill(CommonPlaySkill):
         Args:
             data (dict):        Data returned by self.spotify.search
             data_type (str):    The type of data contained in the passed-in
-                                object. 'track', 'album', or 'genre' are
-                                currently supported.
+                                object. 'saved_tracks', 'track', 'album',
+                                or 'genre' are currently supported.
             genre_name (str):   If type is 'genre', also include the genre's
                                 name here, for output purposes. default None
         """
         try:
-            if data_type == 'track':
+            if data_type == 'saved_tracks':
+                items = data['saved_tracks']['items']
+                random.shuffle(items)
+                uris = []
+                for item in items:
+                    uris.append(item['uri'])
+                data = {'track': items[0]['name'],
+                        'artist': items[0]['artists'][0]['name']}
+                self.speak_dialog('ListeningToSavedSongs', data)
+                time.sleep(2)
+                self.spotify_play(dev['id'], uris=uris)
+            elif data_type == 'track':
                 (song, artists, uri) = get_song_info(data)
                 self.speak_dialog('ListeningToSongBy',
                                   data={'tracks': song,

--- a/__init__.py
+++ b/__init__.py
@@ -172,7 +172,7 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
-        self.saved_tracks = []
+        self.saved_tracks = None
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
@@ -484,9 +484,8 @@ class SpotifySkill(CommonPlaySkill):
         """
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
-        if match:
+        if match and self.saved_tracks:
             return (1.0, {'data': self.saved_tracks,
-                          'name': None,
                           'type': 'saved_tracks'})
 
         # Check if playlist
@@ -978,11 +977,12 @@ class SpotifySkill(CommonPlaySkill):
             if data_type == 'saved_tracks':
                 items = data
                 uris = []
+                for item in items:
+                    uris.append(item['uri'])
                 data = {'track': items[0]['name'],
                         'artist': items[0]['artists'][0]['name']}
                 self.speak_dialog('ListeningToSavedSongs', data)
-                for item in items:
-                    uris.append(item['uri'])
+                time.sleep(2)
                 self.spotify_play(dev['id'], uris=uris)
             elif data_type == 'track':
                 (song, artists, uri) = get_song_info(data)

--- a/__init__.py
+++ b/__init__.py
@@ -788,9 +788,7 @@ class SpotifySkill(CommonPlaySkill):
         now = time.time()
         if not self._saved_tracks or (now - self.__saved_tracks_fetched > 5 * 60):
             self._saved_tracks = {}
-            tracks = self.spotify.current_user_saved_tracks().get('items', [])
-            for t in tracks:
-                self._saved_tracks[t['name'].lower()] = t
+            self._saved_tracks = self.spotify.current_user_saved_tracks().get('items', [])
             self.__saved_tracks_fetched = now
         return self._saved_tracks
 

--- a/__init__.py
+++ b/__init__.py
@@ -977,12 +977,11 @@ class SpotifySkill(CommonPlaySkill):
             if data_type == 'saved_tracks':
                 items = data
                 uris = []
-                for item in items:
-                    uris.append(item['uri'])
                 data = {'track': items[0]['name'],
                         'artist': items[0]['artists'][0]['name']}
                 self.speak_dialog('ListeningToSavedSongs', data)
-                time.sleep(2)
+                for item in items:
+                    uris.append(item['uri'])
                 self.spotify_play(dev['id'], uris=uris)
             elif data_type == 'track':
                 (song, artists, uri) = get_song_info(data)

--- a/__init__.py
+++ b/__init__.py
@@ -172,6 +172,7 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
+        self.saved_tracks = None
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
@@ -258,6 +259,11 @@ class SpotifySkill(CommonPlaySkill):
                 if self.process:
                     self.stop_librespot()
                 self.launch_librespot()
+
+            # Refresh saved tracks
+            # We can't get this list when the user asks because it takes too long
+            # and causes mycroft-playback-control.mycroftai:PlayQueryTimeout
+            self.refresh_saved_tracks()
 
     def load_credentials(self):
         """Retrieve credentials from the backend and connect to Spotify."""
@@ -479,7 +485,7 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
-            return (1.0, {'data': self.saved_tracks(),
+            return (1.0, {'data': self.saved_tracks,
                           'type': 'saved_tracks'})
 
         # Check if playlist
@@ -779,26 +785,24 @@ class SpotifySkill(CommonPlaySkill):
             self.__playlists_fetched = now
         return self._playlists
 
-    def saved_tracks(self, count=100):
-        """Retrieve count number of saved tracks."""
+    def refresh_saved_tracks(self):
+        """Saved tracks are cached for 4 hours."""
         if not self.spotify:
             return []
+        now = time.time()
+        if not self.saved_tracks or (now - self.__saved_tracks_fetched > 4 * 60 * 60):
+            saved_tracks = []
+            offset = 0
+            while True:
+                batch = self.spotify.current_user_saved_tracks(50, offset)
+                for item in batch.get('items', []):
+                    saved_tracks.append(item['track'])
+                offset += 50
+                if not batch['next']:
+                    break
 
-        songs = []
-
-        # Get the amount of tracks
-        batch = self.spotify.current_user_saved_tracks(1, 0)
-        total = batch["total"]
-
-        # Get less tracks if the user has less than count
-        if total < count:
-            count = total
-
-        # Grab count random tracks
-        for i in range(0, count):
-            songs.append(self.spotify.current_user_saved_tracks(1, random.randint(0, total)).get('items', []))
-
-        return songs
+            self.saved_tracks = saved_tracks
+            self.__saved_tracks_fetched = now
 
     @property
     def devices(self):
@@ -972,6 +976,7 @@ class SpotifySkill(CommonPlaySkill):
         try:
             if data_type == 'saved_tracks':
                 items = data
+                uris = []
                 for item in items:
                     uris.append(item['uri'])
                 data = {'track': items[0]['name'],

--- a/__init__.py
+++ b/__init__.py
@@ -977,9 +977,9 @@ class SpotifySkill(CommonPlaySkill):
         try:
             if data_type == 'saved_tracks':
                 items = data
-                # Grab up to 100 random songs
+                # Grab up to 50 random songs
                 # Prevents mycroft-playback-control.mycroftai:PlayQueryTimeout
-                random.sample(items, min(100, len(items)))
+                random.sample(items, min(50, len(items)))
                 uris = []
                 for item in items:
                     uris.append(item['uri'])

--- a/__init__.py
+++ b/__init__.py
@@ -172,7 +172,7 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
-        self._saved_tracks = None
+        self.saved_tracks = None
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
@@ -790,7 +790,7 @@ class SpotifySkill(CommonPlaySkill):
         if not self.spotify:
             return []
         now = time.time()
-        if not self._saved_tracks or (now - self.__saved_tracks_fetched > 4 * 60 * 60):
+        if not self.saved_tracks or (now - self.__saved_tracks_fetched > 4 * 60 * 60):
             saved_tracks = []
             offset = 0
             while True:
@@ -802,7 +802,7 @@ class SpotifySkill(CommonPlaySkill):
                 if not batch['next']:
                     break
 
-            self._saved_tracks = saved_tracks
+            self.saved_tracks = saved_tracks
             self.__saved_tracks_fetched = now
 
     @property

--- a/__init__.py
+++ b/__init__.py
@@ -480,7 +480,8 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
-            return self.query_saved_songs()
+            return (1.0, {'data': self.saved_tracks,
+                           'type': 'saved_tracks'})
 
         # Check if playlist
         match = re.match(self.translate_regex('playlist'), phrase)

--- a/__init__.py
+++ b/__init__.py
@@ -172,7 +172,6 @@ class SpotifySkill(CommonPlaySkill):
         self.platform = enclosure_config.get('platform', 'unknown')
         self.DEFAULT_VOLUME = 80 if self.platform == 'mycroft_mark_1' else 100
         self._playlists = None
-        self.saved_tracks = None
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
@@ -259,11 +258,6 @@ class SpotifySkill(CommonPlaySkill):
                 if self.process:
                     self.stop_librespot()
                 self.launch_librespot()
-
-            # Refresh saved tracks
-            # We can't get this list when the user asks because it takes too long
-            # and causes mycroft-playback-control.mycroftai:PlayQueryTimeout
-            self.refresh_saved_tracks()
 
     def load_credentials(self):
         """Retrieve credentials from the backend and connect to Spotify."""
@@ -485,7 +479,7 @@ class SpotifySkill(CommonPlaySkill):
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase)
         if match:
-            return (1.0, {'data': self.saved_tracks,
+            return (1.0, {'data': self.saved_tracks(),
                           'type': 'saved_tracks'})
 
         # Check if playlist
@@ -785,25 +779,26 @@ class SpotifySkill(CommonPlaySkill):
             self.__playlists_fetched = now
         return self._playlists
 
-    def refresh_saved_tracks(self):
-        """Saved tracks are cached for 4 hours."""
+    def saved_tracks(self, count=100):
+        """Retrieve count number of saved tracks."""
         if not self.spotify:
             return []
-        now = time.time()
-        if not self.saved_tracks or (now - self.__saved_tracks_fetched > 4 * 60 * 60):
-            saved_tracks = []
-            offset = 0
-            while True:
-                batch = self.spotify.current_user_saved_tracks(50, offset)
-                for item in batch.get('items', []):
-                    saved_tracks.append(item['track'])
 
-                offset += 50
-                if not batch['next']:
-                    break
+        songs = []
 
-            self.saved_tracks = saved_tracks
-            self.__saved_tracks_fetched = now
+        # Get the amount of tracks
+        batch = self.spotify.current_user_saved_tracks(1, 0)
+        total = batch["total"]
+
+        # Get less tracks if the user has less than count
+        if total < count:
+            count = total
+
+        # Grab count random tracks
+        for i in range(0, count):
+            songs.append(self.spotify.current_user_saved_tracks(1, random.randint(0, total)).get('items', [])
+
+        return songs
 
     @property
     def devices(self):
@@ -977,10 +972,6 @@ class SpotifySkill(CommonPlaySkill):
         try:
             if data_type == 'saved_tracks':
                 items = data
-                # Grab up to 100 random songs
-                # Prevents mycroft-playback-control.mycroftai:PlayQueryTimeout
-                random.choices(items, k=min(100, len(items)))
-                uris = []
                 for item in items:
                     uris.append(item['uri'])
                 data = {'track': items[0]['name'],

--- a/__init__.py
+++ b/__init__.py
@@ -976,9 +976,9 @@ class SpotifySkill(CommonPlaySkill):
                 random.shuffle(items)
                 uris = []
                 for item in items:
-                    uris.append(item['track']['uri'])
-                data = {'track': items[0]['track']['name'],
-                        'artist': items[0]['track']['artists'][0]['name']}
+                    uris.append(item['uri'])
+                data = {'track': items[0]['name'],
+                        'artist': items[0]['artists'][0]['name']}
                 self.speak_dialog('ListeningToSavedSongs', data)
                 time.sleep(2)
                 self.spotify_play(dev['id'], uris=uris)

--- a/locale/en-us/ListeningToSavedSongs.dialog
+++ b/locale/en-us/ListeningToSavedSongs.dialog
@@ -1,0 +1,4 @@
+Okay, let's hear your saved songs. Starting with {{track}} by {{artist}}
+Let's hear some of your saved songs. Starting with {{track}} by {{artist}}
+Let's hear some of your saved songs. This is {{track}} by {{artist}}
+Playing your saved songs. Starting off with {{track}} by {{artist}}

--- a/locale/en-us/ListeningToSavedSongs.dialog
+++ b/locale/en-us/ListeningToSavedSongs.dialog
@@ -1,4 +1,3 @@
-Okay, let's hear your saved songs. Starting with {{track}} by {{artist}}
-Let's hear some of your saved songs. Starting with {{track}} by {{artist}}
-Let's hear some of your saved songs. This is {{track}} by {{artist}}
-Playing your saved songs. Starting off with {{track}} by {{artist}}
+Okay, let's hear your saved songs.
+Let's hear some of your saved songs.
+Playing your saved songs.

--- a/locale/en-us/saved_songs.regex
+++ b/locale/en-us/saved_songs.regex
@@ -1,0 +1,1 @@
+(my |)(spotify |)(liked|saved) songs


### PR DESCRIPTION
Fixes #125.

This was painful. Spotify's API is... inconsistent. And Mycroft didn't like me returning a HUGE data payload to the Playback Control Skill.

But this works. This works great. It's fast, it picks a different 200 random songs each time you tell it to play your liked songs. It even handles it well if you literally, like me, have thousands and thousands of saved songs.

Oh yeah, please squash these commits when you merge it :)