### PR TITLE
Remove extra ')' from spanish regex translation

### DIFF
--- a/locale/es-es/artist.regex
+++ b/locale/es-es/artist.regex
@@ -1,1 +1,1 @@
-(el artista|el grupo|la banda|(algo|cualquier cosa|cosa|música|canciones) de)) (?P<artist>.+)
+(el artista|el grupo|la banda|(algo|cualquier cosa|cosa|música|canciones) de) (?P<artist>.+)


### PR DESCRIPTION
Hopefully fixes running the skill in Spanish, and should resolve #147