### PR TITLE
Local api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # <img src='https://rawcdn.githack.com/forslund/spotify-skill/05c19c0fba8a4af150c6eb8cf2e955d59ac83d15/Spotify_Icon.png' card_color='#40db60' width='50' height='50' style='vertical-align:bottom'/> Play Spotify
 
-**Spotify has disabled my API access for the skill, it was violating their Terms of Service by enabling voice control. I must have missed this back in 2017 when I created the skill.**
+Listen to music from your Spotify Premium music account.
 
-To use this skill currently you will need to create your own "application using
-https://developer.spotify.com". See instructions under the heading "Personal access token"
-.
+**Spotify has disabled the API access for the skill, you will need to create your own. Instructions below.**
+
+To use this skill currently you will need to create your own application using [The Spotify developer dashboard](https://developer.spotify.com/dashboard/) due to Spotify policy (see *Spotify Authentication reason* for some details). Detailed instructions are available below under *Personal Access Token*.
+
 Listen to music from your Spotify Premium music account
 
 ## About
@@ -41,12 +42,24 @@ The exception to this is the Mark-1 which is shipped with a spotify player libra
 ### Authorization:
 This Skill uses two different methods of authentication. Both need to be filled in correctly for the **Skill** to function correctly.
 
-#### API connection to your Spotify account
+#### Personal Access Token
+
+##### Creating access token
+From the [Spotify developer dashboard](https://developer.spotify.com/dashboard/)
+
+1. Click "CREATE AN APP"
+1. Fill out the create application form
+1. Click on the new app and choose EDIT SETTINGS
+1. Under Redirect URIs add `https://localhost:8888`
+
+More info can be found [here](https://developer.spotify.com/documentation/general/guides/app-settings/).
+
+##### Connecting spotify skill
 After installing `mycroft-spotify`, from the mycroft-core folder run the auth.py script in the mycroft-spotify folder
 
 ```
-source venv-activate-sh
-python skills/mycroft-spotify/auth.py
+source venv-activate.sh
+python /opt/mycroft/skills/mycroft-spotify.forslund/auth.py
 ```
 
 The script will try to guide you through connecting a developer account to the skill and store the credentials locally.
@@ -97,3 +110,7 @@ The Mycroft devs
 ## Tags
 #spotify
 #music
+
+## Spotify Authentication reason
+
+Spotify disabled my API access for the skill in August 2020, it was violating their Terms of Service by enabling voice control. I must have missed this back in 2017 when I created the skill. With some luck I can convince Spotify that since the skill is totally non-commercial and open source we may have a single API key for the skill.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **Spotify has disabled my API access for the skill, it was violating their Terms of Service by enabling voice control. I must have missed this back in 2017 when I created the skill.**
 
+To use this skill currently you will need to create your own "application using
+https://developer.spotify.com". See instructions under the heading "Personal access token"
+.
 Listen to music from your Spotify Premium music account
 
 ## About
@@ -39,13 +42,19 @@ The exception to this is the Mark-1 which is shipped with a spotify player libra
 This Skill uses two different methods of authentication. Both need to be filled in correctly for the **Skill** to function correctly.
 
 #### API connection to your Spotify account
-After installing `mycroft-spotify`, in your [Skill
-settings for Spotify](https://home.mycroft.ai/#/skill) in home.mycroft.ai you will see settings for the Spotify Skill. You will see a username and password field and a 'Connect' button. Ignore the username and password field for now, and click the 'Connect' button. You will be prompted to log in to Spotify, and to authorize Mycroft AI to use your Spotify account using OAuth. This allows Mycroft access to your account details such as Playlists.
+After installing `mycroft-spotify`, from the mycroft-core folder run the auth.py script in the mycroft-spotify folder
+
+```
+source venv-activate-sh
+python skills/mycroft-spotify/auth.py
+```
+
+The script will try to guide you through connecting a developer account to the skill and store the credentials locally.
 
 #### Username and password to authenticate a Mycroft device
 In addition to account details, Mycroft needs to be authorized as a **device** for Spotify. To do this, we use your username and password for Spotify. These must be entered as well, or you will receive an error message like:
 
-`I couldn't find any Spot-ify devices.  This skill requires a Spotify Premium account to work properly.`
+`I couldn't find any Spotify devices.  This skill requires a Spotify Premium account to work properly.`
 
 when you try to use the **Skill** on a Mycroft device.
 

--- a/__init__.py
+++ b/__init__.py
@@ -177,7 +177,8 @@ class SpotifySkill(CommonPlaySkill):
         self.regexes = {}
         self.last_played_type = None  # The last uri type that was started
         self.is_playing = False
-
+        self.__saved_tracks_fetched = 0
+        
     def translate_regex(self, regex):
         if regex not in self.regexes:
             path = self.find_resource(regex + '.regex')
@@ -831,11 +832,11 @@ class SpotifySkill(CommonPlaySkill):
 
     def refresh_saved_tracks(self):
         """Saved tracks are cached for 4 hours."""
-        return []
         if not self.spotify:
             return []
         now = time.time()
-        if not self.saved_tracks or (now - self.__saved_tracks_fetched > 4 * 60 * 60):
+        if not (self.saved_tracks or
+                (now - self.__saved_tracks_fetched > 4 * 60 * 60)):
             saved_tracks = []
             offset = 0
             while True:

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,62 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from os import mkdir
+from os.path import exists, join
+import spotipy
+from spotipy import SpotifyOAuth
+from xdg import BaseDirectory
+
+auth_dir = BaseDirectory.save_config_path('spotipy')
+
+print("""This script creates the token information needed for running spotify
+      with a set of personal developer credentials.
+
+      It requires the user to go to developer.spotify.com and set up a
+      developer account, create an "Application" and make sure to whitelist
+      "https://localhost:8888".
+
+      After you have done that enter the information when prompted and follow
+      the instructions given.
+""")
+
+CLIENT_ID = input('YOUR CLIENT ID: ')
+CLIENT_SECRET = input('YOUR CLIENT SECRET: ')
+REDIRECT_URI = 'https://localhost:8888'
+SCOPE = ('user-library-read streaming playlist-read-private user-top-read '
+         'user-read-playback-state')
+
+if not exists(auth_dir):
+    mkdir(auth_dir)
+
+am = SpotifyOAuth(scope=SCOPE, client_id=CLIENT_ID,
+                  client_secret=CLIENT_SECRET, redirect_uri=REDIRECT_URI,
+                  cache_path=join(auth_dir, 'token'))
+
+token_info = am.validate_token(am.cache_handler.get_cached_token())
+if not token_info:
+    code = am.get_auth_response()
+    token = am.get_access_token(code, as_dict=False)
+sp = spotipy.Spotify(auth_manager=am)
+
+
+choice_valid = False
+while not choice_valid:
+    choice = input('Do you want to save the Client Secrets? (y/n) ')
+    choice_valid = choice.lower() in ('yes', 'y', 'no', 'n')
+
+if choice in ('yes', 'y'):
+    info = {'client_id': CLIENT_ID, 'client_secret': CLIENT_SECRET}
+    with open(join(auth_dir, 'auth'), 'w') as f:
+        json.dump(info, f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-spotipy==2.4.4
+spotipy==2.17.1


### PR DESCRIPTION
Add support for using personal developer keys.

This adds a simple auth script to help create local credentials and store them in a specific path for usage by the skill. It also offers to save the client_id and client_secret for convenience (but will work with passing those as environment variables as well)