### PR TITLE
Custom auth storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ From the [Spotify developer dashboard](https://developer.spotify.com/dashboard/)
 
 More info can be found [here](https://developer.spotify.com/documentation/general/guides/app-settings/).
 
+The config will by default be stored in the `XDG_CONFIG` directory, which is often `~/.configi`, so by default the generated files are found in `~/.config/spotipy/`. If you wish to use another directory you can set the environment variable `SPOTIFY_SKILL_CREDS_DIR` to the directory where you'd like to store the config. This is useful when running in docker for example.
+
 ##### Connecting spotify skill
 After installing `mycroft-spotify`, from the mycroft-core folder run the auth.py script in the mycroft-spotify folder
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Mycroft AI Inc.
+# Copyright 2021 Åke Forslund
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/auth.py
+++ b/auth.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 from os import mkdir
 from os.path import exists, join
 
@@ -19,7 +20,8 @@ import spotipy
 from spotipy import SpotifyOAuth
 from xdg import BaseDirectory
 
-AUTH_DIR = BaseDirectory.save_config_path('spotipy')
+AUTH_DIR = os.environ.get('SPOTIFY_SKILL_CREDS_DIR',
+                          BaseDirectory.save_config_path('spotipy'))
 SCOPE = ('user-library-read streaming playlist-read-private user-top-read '
          'user-read-playback-state')
 

--- a/auth.py
+++ b/auth.py
@@ -14,50 +14,56 @@
 import json
 from os import mkdir
 from os.path import exists, join
+
 import spotipy
 from spotipy import SpotifyOAuth
 from xdg import BaseDirectory
 
-auth_dir = BaseDirectory.save_config_path('spotipy')
-
-print("""This script creates the token information needed for running spotify
-      with a set of personal developer credentials.
-
-      It requires the user to go to developer.spotify.com and set up a
-      developer account, create an "Application" and make sure to whitelist
-      "https://localhost:8888".
-
-      After you have done that enter the information when prompted and follow
-      the instructions given.
-""")
-
-CLIENT_ID = input('YOUR CLIENT ID: ')
-CLIENT_SECRET = input('YOUR CLIENT SECRET: ')
-REDIRECT_URI = 'https://localhost:8888'
+AUTH_DIR = BaseDirectory.save_config_path('spotipy')
 SCOPE = ('user-library-read streaming playlist-read-private user-top-read '
          'user-read-playback-state')
 
-if not exists(auth_dir):
-    mkdir(auth_dir)
 
-am = SpotifyOAuth(scope=SCOPE, client_id=CLIENT_ID,
-                  client_secret=CLIENT_SECRET, redirect_uri=REDIRECT_URI,
-                  cache_path=join(auth_dir, 'token'),
-                  open_browser=False)
-
-token_info = am.validate_token(am.cache_handler.get_cached_token())
-if not token_info:
-    code = am.get_auth_response()
-    token = am.get_access_token(code, as_dict=False)
-sp = spotipy.Spotify(auth_manager=am)
+def ensure_auth_dir_exists():
+    if not exists(AUTH_DIR):
+        mkdir(AUTH_DIR)
 
 
-choice_valid = False
-while not choice_valid:
-    choice = input('Do you want to save the Client Secrets? (y/n) ')
-    choice_valid = choice.lower() in ('yes', 'y', 'no', 'n')
+if __name__ == '__main__':
+    print(
+        """This script creates the token information needed for running spotify
+        with a set of personal developer credentials.
 
-if choice in ('yes', 'y'):
-    info = {'client_id': CLIENT_ID, 'client_secret': CLIENT_SECRET}
-    with open(join(auth_dir, 'auth'), 'w') as f:
-        json.dump(info, f)
+        It requires the user to go to developer.spotify.com and set up a
+        developer account, create an "Application" and make sure to whitelist
+        "https://localhost:8888".
+
+        After you have done that enter the information when prompted and follow
+        the instructions given.
+        """)
+
+    CLIENT_ID = input('YOUR CLIENT ID: ')
+    CLIENT_SECRET = input('YOUR CLIENT SECRET: ')
+    REDIRECT_URI = 'https://localhost:8888'
+
+    ensure_auth_dir_exists()
+    am = SpotifyOAuth(scope=SCOPE, client_id=CLIENT_ID,
+                      client_secret=CLIENT_SECRET, redirect_uri=REDIRECT_URI,
+                      cache_path=join(AUTH_DIR, 'token'),
+                      open_browser=False)
+
+    token_info = am.validate_token(am.cache_handler.get_cached_token())
+    if not token_info:
+        code = am.get_auth_response()
+        token = am.get_access_token(code, as_dict=False)
+    sp = spotipy.Spotify(auth_manager=am)
+
+    choice_valid = False
+    while not choice_valid:
+        choice = input('Do you want to save the Client Secrets? (y/n) ')
+        choice_valid = choice.lower() in ('yes', 'y', 'no', 'n')
+
+    if choice in ('yes', 'y'):
+        info = {'client_id': CLIENT_ID, 'client_secret': CLIENT_SECRET}
+        with open(join(AUTH_DIR, 'auth'), 'w') as f:
+            json.dump(info, f)

--- a/spotify.py
+++ b/spotify.py
@@ -6,10 +6,11 @@ import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
 from requests import HTTPError
 import time
-from xdg import BaseDirectory
 
 from mycroft.api import DeviceApi
 from mycroft.util.log import LOG
+
+from .auth import AUTH_DIR, SCOPE
 
 
 def get_token(dev_cred):
@@ -64,14 +65,10 @@ def refresh_auth(func):
 
 
 def load_local_credentials(user):
-    scope = ('user-library-read streaming playlist-read-private '
-             'user-top-read user-read-playback-state')
-    auth_dir = BaseDirectory.save_config_path('spotipy')
+    if not exists(AUTH_DIR):
+        os.mkdir(AUTH_DIR)
 
-    if not exists(auth_dir):
-        os.mkdir(auth_dir)
-
-    token_cache = join(auth_dir, 'token')
+    token_cache = join(AUTH_DIR, 'token')
 
     # Move old creds to config path
     old_cache_file = '.cache-{}'.format(user)
@@ -79,7 +76,7 @@ def load_local_credentials(user):
         move(old_cache_file, token_cache)
 
     # Load stored oauth credentials if exists
-    auth_cache = join(auth_dir, 'auth')
+    auth_cache = join(AUTH_DIR, 'auth')
     if exists(auth_cache):
         with open(auth_cache) as f:
             auth = json.load(f)
@@ -88,7 +85,7 @@ def load_local_credentials(user):
 
     return SpotifyOAuth(username=user,
                         redirect_uri='https://localhost:8888',
-                        scope=scope,
+                        scope=SCOPE,
                         cache_path=token_cache)
 
 


### PR DESCRIPTION
This adds the possibility to add a custom location for storing the spotify credentials using the environment variable `SPOTIFY_SKILL_CREDS_DIR`.

This can be used for example in a docker context where the credentials should be stored in an attached volume. This should resolve #165