### PR TITLE
Feature/allow master control

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -381,7 +381,6 @@ class SpotifySkill(CommonPlaySkill):
         # Checks once a second for feedback
         status = self.spotify.status() if self.spotify else {}
         self.is_playing = self.spotify.is_playing()
-        self.log.info(self.is_playing)
 
         if not status or not status.get('is_playing'):
             self.stop_monitor()

--- a/__init__.py
+++ b/__init__.py
@@ -812,8 +812,6 @@ class SpotifySkill(CommonPlaySkill):
         self.enable_intent('StopMusic.intent')
 
     def disable_playing_intents(self):
-        # If allow_master_control is false, disable these intents (called
-        # when music stops playing)
         self.disable_intent('WhatSong.intent')
         self.disable_intent('WhatAlbum.intent')
         self.disable_intent('WhatArtist.intent')


### PR DESCRIPTION
#### Description
Two separate changes:
- Enabling "what song is this?"/"What are we listening to?" functionality, that was mostly already implemented, but commented out...? It seems to all work well (#7 )
- Adding option to allow mycroft to control playback on other spotify devices, if allow_master_control is set to true in settings.json (e.g. 'play the artist the beatles' will start playback on the primary device; 'transfer spotify to <name of another spotify device>' will transfer playback, then 'pause'/'next track' etc will control playback on the device that playback was transferred to).

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [X] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
These changes have only been tested on picroft; if anyone can test them on a Mark1 or Mark2, that would be good.

#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?